### PR TITLE
Moon relative velocity hardcoded to 0 in sim mode

### DIFF
--- a/src/app/api/snapshot/route.ts
+++ b/src/app/api/snapshot/route.ts
@@ -39,7 +39,7 @@ export async function GET(request: Request): Promise<Response> {
           metMs: sv.met_ms,
           speedKmS: sv.speed_km_s,
           speedKmH: sv.speed_km_h,
-          moonRelSpeedKmH: 0, // not available in historical snapshots
+          moonRelSpeedKmH: sv.moon_rel_speed_km_h ?? 0,
           altitudeKm: sv.altitude_km,
           earthDistKm: sv.earth_dist_km,
           moonDistKm: sv.moon_dist_km,

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -442,14 +442,14 @@ export function getStateSnapshotAt(metMs: number): {
   vel_x: number; vel_y: number; vel_z: number;
   moon_x: number | null; moon_y: number | null; moon_z: number | null;
   earth_dist_km: number; moon_dist_km: number;
-  speed_km_s: number; speed_km_h: number; altitude_km: number;
+  speed_km_s: number; speed_km_h: number; moon_rel_speed_km_h: number | null; altitude_km: number;
   periapsis_km: number; apoapsis_km: number; g_force: number;
 } | null {
   const db = getDb();
   return db.prepare(`
     SELECT timestamp, met_ms, pos_x, pos_y, pos_z, vel_x, vel_y, vel_z,
            moon_x, moon_y, moon_z, earth_dist_km, moon_dist_km,
-           speed_km_s, speed_km_h, altitude_km, periapsis_km, apoapsis_km, g_force
+           speed_km_s, speed_km_h, moon_rel_speed_km_h, altitude_km, periapsis_km, apoapsis_km, g_force
     FROM state_vectors
     WHERE met_ms <= ?
     ORDER BY met_ms DESC


### PR DESCRIPTION
In sim mode, "moonRelSpeedKmH" was hardcoded to 0 in the "/api/snapshot" route with a comment saying it wasn't available in historical snapshots. However, the value is actually stored in the "state_vectors" table as "moon_rel_speed_km_h" (added in migration 2) -- it just wasn't included in the SELECT query in "getStateSnapshotAt."

Fix:
- Add "moon_rel_speed_km_h" to the SELECT in "getStateSnapshotAt"
- Update the return type to include "moon_rel_speed_km_h: number | null"
- Read the value in the snapshot route instead of hardcoding 0

Rows written before migration 2 will have NULL for this column and will correctly display as "-" in the UI, with only rows written after this having values (better than nothing?)

PS. So sorry if I did the pr wrong or something; I'm not great a git stuff, but at least the code should be decent.